### PR TITLE
UIManager.cs 修改

### DIFF
--- a/Assets/QFramework/Framework/2.UIKit/1.UI/Script/System/UIManager.cs
+++ b/Assets/QFramework/Framework/2.UIKit/1.UI/Script/System/UIManager.cs
@@ -279,39 +279,33 @@ namespace QFramework
 			switch (level)
 			{
 				case UILevel.Bg:
-					ui.Transform.SetParent(mBgTrans);
+					ui.Transform.SetParent(mBgTrans,false);
 					break;
 				case UILevel.AnimationUnderPage:
-					ui.Transform.SetParent(mAnimationUnderTrans);
+					ui.Transform.SetParent(mAnimationUnderTrans,false);
 					break;
 				case UILevel.Common:
-					ui.Transform.SetParent(mCommonTrans);
+					ui.Transform.SetParent(mCommonTrans,false);
 					break;
 				case UILevel.AnimationOnPage:
-					ui.Transform.SetParent(mAnimationOnTrans);
+					ui.Transform.SetParent(mAnimationOnTrans,false);
 					break;
 				case UILevel.PopUI:
-					ui.Transform.SetParent(mPopUITrans);
+					ui.Transform.SetParent(mPopUITrans,false);
 					break;
 				case UILevel.Const:
-					ui.Transform.SetParent(mConstTrans);
+					ui.Transform.SetParent(mConstTrans,false);
 					break;
 				case UILevel.Toast:
-					ui.Transform.SetParent(mToastTrans);
+					ui.Transform.SetParent(mToastTrans,false);
 					break;
 				case UILevel.Forward:
-					ui.Transform.SetParent(mForwardTrans);
+					ui.Transform.SetParent(mForwardTrans,false);
 					break;
 			}
 
 			var uiGoRectTrans = ui.Transform as RectTransform;
-
-			uiGoRectTrans.offsetMin = Vector2.zero;
-			uiGoRectTrans.offsetMax = Vector2.zero;
-			uiGoRectTrans.anchoredPosition3D = Vector3.zero;
-			uiGoRectTrans.anchorMin = Vector2.zero;
-			uiGoRectTrans.anchorMax = Vector2.one;
-
+			
 			ui.Transform.LocalScaleIdentity();
 			ui.Transform.gameObject.name = uiBehaviourName;
 


### PR DESCRIPTION
修改前：
无论什么大小的预制体，在使用UIMgr.OpenPanel动态创建面板时，总会占满全屏。
修改后：
保证创建出来的预制体保持原有的分辨率和布局。