### PR TITLE
使架构 Architecture 内部事件处理器也可通过接口定义，并能一键注册/注销

### DIFF
--- a/QFramework.Unity2018+/Assets/QFramework/Framework/Scripts/QFramework.cs
+++ b/QFramework.Unity2018+/Assets/QFramework/Framework/Scripts/QFramework.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using UnityEngine;
 
 namespace QFramework


### PR DESCRIPTION
模仿 CommunityToolkit.Mvvm 中 ObservableRecipient 和 IRecipient<T> 的使用方式。
现在可通过如下方式声明架构内事件处理器并注册：
```csharp
public class Player : ViewController, IController,
    IOnEventInArchitecture<AEvent>,
    IOnEventInArchitecture<BEvent>
{
    public void OnEventInArchitecture(AEvent e) { \* handle AEvent ... *\ }
    public void OnEventInArchitecture(BEvent e) { \* handle BEvent ... *\ }

    void Awake()
    {
        this.RegisterAllEventInArchitecture(this); // 一键注册
    }
}
```
其中 `RegisterAllEventInArchitecture` 方法默认使事件处理器在 `gameObject` 销毁后自动注销，通过参数 `isAutoUnregister` 可控制。
`UnRegisterAllEventInArchitecture` 方法用于一键注销这些事件处理器。