### PR TITLE
修复（Unity）：打开包工具面板时避免DX12崩溃

### DIFF
--- a/QFramework.Unity2018+/Assets/QFramework/Toolkits/_CoreKit/PackageKit/Markdown/MDHandlerImages.cs
+++ b/QFramework.Unity2018+/Assets/QFramework/Toolkits/_CoreKit/PackageKit/Markdown/MDHandlerImages.cs
@@ -95,7 +95,7 @@ namespace QFramework
 
                 while (img != null)
                 {
-                    anim.Add(img.CreateTexture(), img.Delay / 1000.0f);
+                    anim.Add(img.CreateTexture(), img.Delay > 0 ? img.Delay / 1000.0f : 0.1f);
                     img = decoder.NextImage();
                 }
 

--- a/QFramework.Unity2018+/Assets/QFramework/Toolkits/_CoreKit/PackageKit/Markdown/MDMGGifs.cs
+++ b/QFramework.Unity2018+/Assets/QFramework/Toolkits/_CoreKit/PackageKit/Markdown/MDMGGifs.cs
@@ -36,13 +36,34 @@ namespace QFramework
 
         public Texture2D CreateTexture()
         {
-            var tex = new Texture2D(Width, Height, TextureFormat.ARGB32, false)
+            if (Width <= 0 || Height <= 0)
+            {
+                return Texture2D.blackTexture;
+            }
+
+            var expectedPixelCount = Width * Height;
+            var pixels = RawImage;
+
+            if (pixels == null || pixels.Length != expectedPixelCount)
+            {
+                var sanitizedPixels = new Color32[expectedPixelCount];
+
+                if (pixels != null && pixels.Length > 0)
+                {
+                    Array.Copy(pixels, sanitizedPixels, Math.Min(pixels.Length, sanitizedPixels.Length));
+                }
+
+                pixels = sanitizedPixels;
+            }
+
+            // DX12 下 ARGB32 在部分 Unity 版本会触发底层纹理上传问题，RGBA32 更稳定。
+            var tex = new Texture2D(Width, Height, TextureFormat.RGBA32, false)
             {
                 filterMode = FilterMode.Point,
                 wrapMode = TextureWrapMode.Clamp
             };
 
-            tex.SetPixels32(RawImage);
+            tex.SetPixels32(pixels);
             tex.Apply();
 
             return tex;


### PR DESCRIPTION
#### 修改动机 (Motivation)
- 修复在 DX12 模式下打开 PackageKit 工具面板可能导致的 Unity 编辑器崩溃。该问题源于 GIF 帧纹理上传机制较为脆弱，原逻辑使用 TextureFormat.ARGB32 且缺乏基础的合法性校验。

#### 修改描述 (Description)
- 验证 GIF 维度：增加对帧尺寸的校验，当 Width 或 Height 为非正数时返回 Texture2D.blackTexture，以避免创建无效纹理。
- 规范像素缓冲区：在上传前对解码后的帧像素缓冲区长度进行清理。如果解码数组缺失或长度不匹配，则将其拷贝至尺寸正确的 Color32[] 数组中。
- 更换纹理格式：将运行时纹理格式从 TextureFormat.ARGB32 更改为 TextureFormat.RGBA32，以提高受影响 Unity 版本在 DX12 环境下纹理上传的稳定性。
- 引入最小帧延迟：针对 img.Delay <= 0 的帧添加了 0.1s 的最小延迟回退方案，防止极端情况下的动画过度刷新。

#### 测试背景 (Testing)
- 代码库级检查：已执行暂存、提交并检查了差异（通过 git commit 和 git show --stat）。本次修改涉及两个文件：MDMGGifs.cs 和 MDHandlerImages.cs。
- 真实环境检查：unity6.3.10f1LTS检查通过